### PR TITLE
Add an --offline flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,20 @@ npm install -g available
 
 ## usage
 
+Stream live results from the npm registry:
+
 ```bash
 $ available
 your
 was
 our
 ...
+```
+
+List cached results (faster but out of date):
+
+```bash
+$ available --offline
 ```
 
 ## license

--- a/index.js
+++ b/index.js
@@ -14,14 +14,19 @@ var words = fs.readFileSync(path.join(__dirname, 'dictionary.txt'))
 
 words = difference(words, packageNames)
 
+function offlineResult() {
+  console.error('OFFLINE MODE – printing list of *LIKELY* available package names...')
+  words.forEach(function (word) {
+    console.log(word)
+  })
+}
+
+if (process.argv.slice(2).join(' ').match('--offline')) {
+  return offlineResult()
+}
+
 connectivity(function (online) {
-  if (!online) {
-    console.error('OFFLINE MODE – printing list of *LIKELY* available package names...')
-    words.forEach(function (word) {
-      console.log(word)
-    })
-    return
-  }
+  if (!online) return offlineResult()
 
   var tasks = words.map(function (word) {
     return function (cb) {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/feross/available/issues"
   },
   "dependencies": {
-    "all-the-package-names": "^1.1.0",
+    "all-the-package-names": "^1.3.0",
     "connectivity": "^0.1.2",
     "lodash.difference": "^3.2.2",
     "run-parallel-limit": "^1.0.1",


### PR DESCRIPTION
Hi @feross. This update allows the user to explicitly use the offline list of extant package names:

 ```sh
available --offline
```