### PR TITLE
Handle --version, -v and -r

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -3,6 +3,7 @@
 const available = require('../')
 const connectivity = require('connectivity')
 const minimist = require('minimist')
+const pkg = require('../package.json')
 
 const argv = minimist(process.argv.slice(2), {
   boolean: ['related', 'offline', 'version', 'help'],
@@ -16,6 +17,8 @@ const argv = minimist(process.argv.slice(2), {
 
 if (argv.help) {
   runHelp()
+} else if (argv.version) {
+  runVersion()
 } else {
   if (argv.offline) { // Force offline mode
     run(false)
@@ -48,6 +51,10 @@ Flags:
     -v, --version    Show current version
     -h, --help       Show usage information
   `)
+}
+
+function runVersion () {
+  console.log(pkg.version)
 }
 
 function run (online) {

--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -7,6 +7,7 @@ const minimist = require('minimist')
 const argv = minimist(process.argv.slice(2), {
   boolean: ['related', 'offline', 'version', 'help'],
   alias: {
+    r: 'related',
     o: 'offline',
     v: 'version',
     h: 'help'


### PR DESCRIPTION
`--version`, `-v` and `-r` were documented, but not implemented. This update fixes it.